### PR TITLE
Fix jQuery not working with https

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,8 +3,8 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <title>Admonymous: Anonymous Admonition and Admiration.</title>
-    <script type="text/javascript" charset="utf-8" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-    <link rel="stylesheet" href="http://twitter.github.com/bootstrap/1.3.0/bootstrap.min.css">
+    <script type="text/javascript" charset="utf-8" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+    <link rel="stylesheet" href="https://twitter.github.com/bootstrap/1.3.0/bootstrap.min.css">
     <link rel="stylesheet" href="/static/bootstrap.css" type="text/css" media="screen" charset="utf-8"/>
     <link rel="stylesheet" href="/static/styles.css" type="text/css" media="screen" charset="utf-8"/>
   </head>


### PR DESCRIPTION
On websites opened with HTTPS, browsers will refuse to load resources (scripts, styles) from non-HTTPS sources.
This is the cause of the errors in the JavaScript console when visiting https://www.admonymous.co/

However, browsers will gladly load scripts and styles from HTTPS sources on a page opened with HTTP. Hence, this pull request fixes that problem by always loading the styles and jQuery via HTTPS 🔒 :slightly_smiling_face: 