### PR TITLE
Add collapsible "things I'd like feedback on" section to user pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,13 +96,20 @@ class User(ndb.Model):
     google_account_str = ndb.StringProperty() # legacy version google_account, new version google_account_str
     create_date = ndb.DateTimeProperty(auto_now_add=True)
     update_date = ndb.DateTimeProperty(auto_now=True)
-    message = ndb.TextProperty()  # 
+    message = ndb.TextProperty()  #
+    feedback_topics = ndb.TextProperty()  # one topic per line
 
     def message_html(self):
         if not self.message:
             return ""
         msg = self.message.replace("\r\n", "\n").replace("\r", "\n")
         return msg.replace("\n", "<br/>\n")
+
+    def feedback_topics_list(self):
+        if not self.feedback_topics:
+            return []
+        topics = self.feedback_topics.replace("\r\n", "\n").replace("\r", "\n")
+        return [topic.strip() for topic in topics.split("\n") if topic.strip()]
 
     def first_name(self):
         if not self.name:
@@ -322,6 +329,7 @@ def home_post(request):
     raw_name = request.POST.get('name', '')
     user.name = sanitize_user_input(raw_name)
     user.message = sanitize_user_input(request.POST.get('message', ''))
+    user.feedback_topics = sanitize_user_input(request.POST.get('feedback_topics', ''))
     user.put()
 
     template_values = {

--- a/static/styles.css
+++ b/static/styles.css
@@ -49,4 +49,38 @@ div#user-page-welcome {
 	width:51%;
 	float:right;
 	font-size:14px;
+}details#feedback-topics {
+	margin: 0 0 18px 0;
+	padding: 10px 16px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	background: #f9f9f9;
+}
+details#feedback-topics summary {
+	cursor: pointer;
+	color: #00438a;
+	font: 17px Georgia, "Times New Roman", Times, serif;
+	list-style: none;
+}
+details#feedback-topics summary::-webkit-details-marker {
+	display: none;
+}
+details#feedback-topics summary:before {
+	content: "\25b8\00a0";
+	color: #ff801f;
+}
+details#feedback-topics[open] summary:before {
+	content: "\25be\00a0";
+}
+details#feedback-topics[open] summary {
+	margin-bottom: 8px;
+}
+details#feedback-topics ul {
+	margin: 0;
+	padding-left: 22px;
+}
+details#feedback-topics ul li {
+	color: #00438a;
+	font: 16px Georgia, "Times New Roman", Times, serif;
+	line-height: 22px;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -156,6 +156,8 @@
         </div>
         {% endif %}
         <textarea name="message" style="width:502px;height:75px;margin:0 0 4px 0;">{{ user.message|default_if_none:"" }}</textarea><br/>
+        <label for="feedback_topics">Specific things you'd like feedback on, one per line (optional):</label>
+        <textarea name="feedback_topics" id="feedback_topics" style="width:502px;height:75px;margin:0 0 4px 0;">{{ user.feedback_topics|default_if_none:"" }}</textarea><br/>
         <input name="name" value="{{ user.name }}" style="height:29px;"/>
         <input name="username" value="{{ user.username }}" style="height:29px;"/>
         <input type="submit" class="btn secondary" name="submit" value="Change" id="submit"/>
@@ -181,6 +183,8 @@
           <input name="username" value="{{ user.username|default_if_none:"" }}" style="height:29px;"/><br/><br/>
           <label for="message">Write a brief note to tell people what kind of feedback you want (optional):</label>
           <textarea name="message" style="width:502px;height:75px;margin:0 0 4px 0;">{{ user.message|default_if_none:"" }}</textarea><br/><br/>
+          <label for="feedback_topics">List specific things you'd like feedback on, one per line (optional):</label>
+          <textarea name="feedback_topics" id="feedback_topics" style="width:502px;height:75px;margin:0 0 4px 0;" placeholder="How I run meetings&#10;My writing&#10;Whether I interrupt people">{{ user.feedback_topics|default_if_none:"" }}</textarea><br/><br/>
           <input type="submit" class="btn secondary" name="submit" value="Begin" id="submit" style="float:right;"/>
     	  </fieldset>
       </form>

--- a/templates/user.html
+++ b/templates/user.html
@@ -26,6 +26,17 @@
         {% endif %}
         <div style="clear:both;"></div>
       </div>
+
+      {% if target_user.feedback_topics_list %}
+      <details id="feedback-topics">
+        <summary>Things {{ target_user_first_name|default:"they" }} would like feedback on</summary>
+        <ul>
+          {% for topic in target_user.feedback_topics_list %}
+          <li>{{ topic }}</li>
+          {% endfor %}
+        </ul>
+      </details>
+      {% endif %}
     {% endif %}
 
   <style>


### PR DESCRIPTION
Adds an optional, collapsible list of specific topics a user would like feedback on, shown on their public page above the message form.

## Why

- I think it looks cluttered to put this in the main text box
- when giving feedback, I don't need to see this info if I have a piece of feedback I already intend to give.

## Claude's summary of the change:

- **`main.py`** — `User` gains a `feedback_topics` text property (one topic per line) and a `feedback_topics_list()` helper that splits on newlines and drops blank/whitespace-only entries. `home_post` saves the field through the same `sanitize_user_input` path as `message`.
- **`templates/home.html`** — a matching textarea in the settings form, in both the first-time setup form and the returning-user form. Same markup and styling as the existing note textarea.
- **`templates/user.html`** — renders the topics inside a native `<details>`/`<summary>` element.
- **`static/styles.css`** — styling for the section, using the existing Georgia/`#00438a`/`#ff801f` palette.

## Verification

Rendered the real templates against stand-in data and checked: a user with topics (section present, collapsed, blank lines dropped), a user without topics (section absent), a user with no name set (the summary falls back to "Things they would like feedback on"), and both settings forms (field present, existing value round-trips).